### PR TITLE
Fix for IPv6

### DIFF
--- a/lib/mtrext.js
+++ b/lib/mtrext.js
@@ -8,7 +8,7 @@ const EventEmitter = require('events').EventEmitter;
  * @description This regex pattern is used for extracting the various fields from the returning data. It follows the {@link mtrRoute} object
  */
 // eslint-disable-next-line no-useless-escape
-const regexPatternMtr = /^\s+?(?<hopID>[0-9]+)[.\|\-\s]+(?<hopAddress>[a-zA-Z0-9.i_\-\?]+)\s+(?<loss>[a-zA-Z0-9.]+)%?\s+(?<snt>[a-zA-Z0-9.]+)\s+(?<drop>[a-zA-Z0-9.]+)\s+(?<rcv>[a-zA-Z0-9.]+)\s+(?<last>[a-zA-Z0-9.]+)\s+(?<best>[a-zA-Z0-9.]+)\s+(?<avg>[a-zA-Z0-9.]+)\s+(?<wrst>[a-zA-Z0-9.]+)\s+(?<jttr>[a-zA-Z0-9.]+)\s+(?<javg>[a-zA-Z0-9.]+)\s+(?<jmax>[a-zA-Z0-9.]+)\s+(?<jint>[a-zA-Z0-9.]+)$/i;
+const regexPatternMtr = /^\s+?(?<hopID>[0-9]+)[.\|\-\s]+(?<hopAddress>[a-zA-Z0-9.:i_\-\?]+)\s+(?<loss>[a-zA-Z0-9.]+)%?\s+(?<snt>[a-zA-Z0-9.]+)\s+(?<drop>[a-zA-Z0-9.]+)\s+(?<rcv>[a-zA-Z0-9.]+)\s+(?<last>[a-zA-Z0-9.]+)\s+(?<best>[a-zA-Z0-9.]+)\s+(?<avg>[a-zA-Z0-9.]+)\s+(?<wrst>[a-zA-Z0-9.]+)\s+(?<jttr>[a-zA-Z0-9.]+)\s+(?<javg>[a-zA-Z0-9.]+)\s+(?<jmax>[a-zA-Z0-9.]+)\s+(?<jint>[a-zA-Z0-9.]+)$/i;
 
 /**
  * @property {string} hrstart This varible contains the start time of the call using 'process.hrtime'


### PR DESCRIPTION
Added  colon to the regex so it can correctly identify the hopAddress of IPv6 hosts